### PR TITLE
Resolve XSS / incorrectly displayed tags

### DIFF
--- a/packages/astro-meta-tags/package.json
+++ b/packages/astro-meta-tags/package.json
@@ -1,6 +1,6 @@
 {
     "name": "astro-meta-tags",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "author": "Patrick Arminio",
     "license": "MIT",
     "description": "A Dev Toolbar extension to debug meta tags in your Astro website",

--- a/packages/astro-meta-tags/src/toolbar.ts
+++ b/packages/astro-meta-tags/src/toolbar.ts
@@ -27,11 +27,25 @@ const getWindowContent = () => {
   console.log(twitterMetaTags);
 
   const getSingleTagHtml = ([property, content]: [string, string]) => {
+    let contentTag: HTMLElement | Text;
     if (["og:image", "twitter:image"].includes(property)) {
-      content = `<img src="${content}" />`;
+      contentTag = document.createElement("img");
+      contentTag.setAttribute("src", content);
+    } else {
+      contentTag = document.createTextNode(content);
     }
 
-    return /* html */ `<dt>${property}</dt><dd>${content}</dd>`;
+    const tagHtml = document.createDocumentFragment();
+
+    const propertyName = document.createElement("dt");
+    propertyName.textContent = property;
+
+    const propertyValue = document.createElement("dd");
+    propertyValue.append(contentTag);
+
+    tagHtml.append(propertyName, propertyValue);
+
+    return tagHtml
   };
 
   const getTagsHtml = (
@@ -39,16 +53,24 @@ const getWindowContent = () => {
     tags: [string, string][],
     wrapWithDetails = true
   ) => {
-    const dl = `<dl>${tags.map((tag) => getSingleTagHtml(tag)).join("")}</dl>`;
+    const dl = document.createElement("dl");
 
-    if (!wrapWithDetails) {
-      return dl;
+    for (const tag of tags) {
+      dl.append(getSingleTagHtml(tag));
     }
 
-    return `<details>
-      <summary>${title}</summary>
-      ${dl}
-    </details>`;
+    if (!wrapWithDetails) {
+      return dl.outerHTML;
+    }
+
+    const details = document.createElement("details");
+    
+    const summary = document.createElement("summary");
+    summary.textContent = title;
+
+    details.append(summary, dl);
+
+    return details.outerHTML;
   };
 
   const standardTags = [

--- a/packages/astro-meta-tags/src/toolbar.ts
+++ b/packages/astro-meta-tags/src/toolbar.ts
@@ -24,8 +24,6 @@ const getWindowContent = () => {
     document.querySelectorAll("meta[property^='twitter:']")
   ).map(getTagTuple);
 
-  console.log(twitterMetaTags);
-
   const getSingleTagHtml = ([property, content]: [string, string]) => {
     let contentTag: HTMLElement | Text;
     if (["og:image", "twitter:image"].includes(property)) {


### PR DESCRIPTION
# Changes
Resolves #2 

Update `getSingleTagHtml` and `getTagsHtml` to use `document` APIs rather than string templating to construct their DOM elements. `getTagsHtml` returns `outerHTML` to return the final sanitized HTML, enabling the existing string templating to construct the window to continue to work without needing any changes.

I also removed a `console.log` that I spotted that was logging some elements to my console - I can revert this commit if it is still needed.

# Testing
Locally I changed the description of a blog post in the demo site to `<img src='https://picsum.photos/200' />`. I confirmed before making my changes the text was inserted as HTML causing the image to be embedded, and after my change the text displays as plain text as expected, and confirmed that all other attributes still display as expected.

![image](https://github.com/patrick91/astro-meta-tags/assets/1741548/c151f0b8-bcf0-4c34-a14b-28a8b1989864)
